### PR TITLE
Mapper Delay tolerance is working

### DIFF
--- a/src/mr/rpc.go
+++ b/src/mr/rpc.go
@@ -27,8 +27,8 @@ type MrReply struct {
 
 type MapperRequest struct {
 	FileName              []string
-	MapperState           int
 	OriginalFileAllocated string
+	WorkerNum             int
 }
 
 type ReducerRequest struct {


### PR DESCRIPTION
	Master transfer the work to another worker

	In current code, worker delay is simulated by using random sleep
	When the worker wakes up and finished the job, and if the master timer exipres
	for that worker, then the MapperDone RPC request is rejected by the master

	Because in the master, that file processing has been assigned to someone else

       https://youtu.be/6QtLvTkKpG0